### PR TITLE
Use registered PCL

### DIFF
--- a/include/path_manager/path_manager.h
+++ b/include/path_manager/path_manager.h
@@ -42,6 +42,7 @@ class PathManager {
         double obstacle_dist_threshold_;
         bool path_received_;
         bool adjust_goal_;
+        bool adjust_setpoint_;
         geometry_msgs::PoseStamped last_pos_;
         pcl::PointCloud<pcl::PointXYZ> cloud_map_;
 
@@ -69,13 +70,13 @@ class PathManager {
 
         void positionCallback(const geometry_msgs::PoseStamped& msg);
         void pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr &msg);
-        void livoxPointCloudCallback(const livox_ros_driver::CustomMsg::ConstPtr &msg);
+        // void livoxPointCloudCallback(const livox_ros_driver::CustomMsg::ConstPtr &msg);
         void rawGoalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg);
         pcl::PointCloud<pcl::PointXYZ> transformCloudToMapFrame(pcl::PointCloud<pcl::PointXYZ> cloud_in);
         void setCurrentPath(const nav_msgs::Path::ConstPtr &path);
         void publishSetpoint();
         bool isCloseToSetpoint();
-        void ensureSetpointSafety();
+        void adjustSetpoint();
         void findClosestPointInCloud(pcl::PointCloud<pcl::PointXYZ> cloud, geometry_msgs::Point point_in, 
                                               pcl::PointXYZ &closest_point, float &closest_point_distance);
         void adjustGoal(geometry_msgs::PoseStamped goal);

--- a/launch/path_manager.launch
+++ b/launch/path_manager.launch
@@ -2,18 +2,17 @@
     <arg name="mavros_map_frame" default="map"/>
     <arg name="acceptance_radius" default="2.0"/>
     <arg name="obstacle_dist_threshold" default="2.0"/>
-    <arg name="cloud_topic" default="/livox/lidar"/>
     <arg name="lidar_type" default="4"/>
     <arg name="goal_topic" default="/goal_raw"/>
-    <arg name="adjust_goal" default="false"/>
+    <arg name="adjust_goal" default="true"/>
+    <arg name="adjust_setpoint" default="false"/>
 
     <node pkg="path_manager" type="path_manager_node" respawn="false" name="path_manager" output="screen">
         <param name="mavros_map_frame" value="$(arg mavros_map_frame)"/>
         <param name="acceptance_radius" value="$(arg acceptance_radius)"/>
         <param name="obstacle_dist_threshold" value="$(arg obstacle_dist_threshold)"/>
-        <param name="cloud_topic" value="$(arg cloud_topic)"/>
-        <param name="lidar_type" value="$(arg lidar_type)"/>
         <param name="raw_goal_topic" value="$(arg goal_topic)"/>
         <param name="adjust_goal" value="$(arg adjust_goal)"/>
+        <param name="adjust_setpoint" value="$(arg adjust_setpoint)"/>
     </node>
 </launch>


### PR DESCRIPTION
## Description

Use registered PCL for pointcloud, and add argument for adjusting setpoint. Also requires [this](https://github.com/robotics-88/vehicle-launch/pull/41) branch in vehicle_launch

## Testing

Ensure drone still follows path, and that the goal adjuster works by doing `takeoff 5` in arducopter and then `rostopic pub /goal_raw geometry_msgs/PoseStamped '{header: {stamp: now, frame_id: "map"}, pose: {position: {x: -3.0, y: 22.0, z: 5.0}, orientation: {w: 1.0}}}'`