### PR TITLE
Removing namespace from launch, it is unnecessary

### DIFF
--- a/launch/path_manager.launch
+++ b/launch/path_manager.launch
@@ -8,7 +8,7 @@
     <arg name="adjust_altitude_volume" default="false"/>
     <arg name="default_alt" default="3.0"/>
 
-    <node pkg="path_manager" exec="path_manager_node" namespace="path_manager" output="screen">
+    <node pkg="path_manager" exec="path_manager_node" output="screen">
         <param name="mavros_map_frame" value="$(var mavros_map_frame)"/>
         <param name="acceptance_radius" value="$(var acceptance_radius)"/>
         <param name="obstacle_dist_threshold" value="$(var obstacle_dist_threshold)"/>


### PR DESCRIPTION
This makes the node show up as "/path_manager" instead of "/path_manager/path_manager"