### PR TITLE
Added separate goal and setpoint radius, set defaults to 2 and .5 resp

### DIFF
--- a/include/path_manager/path_manager.h
+++ b/include/path_manager/path_manager.h
@@ -39,7 +39,8 @@ class PathManager : public rclcpp::Node
 
         std::string mavros_map_frame_;
 
-        double acceptance_radius_;
+        double setpoint_acceptance_radius_;
+        double goal_acceptance_radius_;
         double obstacle_dist_threshold_;
         float percent_above_threshold_;
         bool path_received_;

--- a/launch/path_manager.launch
+++ b/launch/path_manager.launch
@@ -1,6 +1,7 @@
 <launch>
     <arg name="mavros_map_frame" default="map"/>
-    <arg name="acceptance_radius" default="2.0"/>
+    <arg name="setpoint_acceptance_radius" default="0.5"/>
+    <arg name="goal_acceptance_radius" default="2.0"/>
     <arg name="obstacle_dist_threshold" default="2.0"/>
     <arg name="goal_topic" default="/goal_raw"/>
     <arg name="adjust_goal" default="false"/>
@@ -12,7 +13,8 @@
 
     <node pkg="path_manager" exec="path_manager_node" output="screen">
         <param name="mavros_map_frame" value="$(var mavros_map_frame)"/>
-        <param name="acceptance_radius" value="$(var acceptance_radius)"/>
+        <param name="setpoint_acceptance_radius" value="$(var setpoint_acceptance_radius)"/>
+        <param name="goal_acceptance_radius" value="$(var goal_acceptance_radius)"/>
         <param name="obstacle_dist_threshold" value="$(var obstacle_dist_threshold)"/>
         <param name="raw_goal_topic" value="$(var goal_topic)"/>
         <param name="adjust_goal" value="$(var adjust_goal)"/>

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -30,7 +30,8 @@ PathManager::PathManager()
   , path_received_(false)
   , goal_init_(false)
   , adjustment_margin_(0.5)
-  , acceptance_radius_(2.0)
+  , setpoint_acceptance_radius_(0.5)
+  , goal_acceptance_radius_(2.0)
   , obstacle_dist_threshold_(2.0)
   , percent_above_(-1.0)
   , percent_above_threshold_(0.01)
@@ -44,7 +45,8 @@ PathManager::PathManager()
 {
 
   // Params
-  this->declare_parameter("acceptance_radius", acceptance_radius_);
+  this->declare_parameter("setpoint_acceptance_radius", setpoint_acceptance_radius_);
+  this->declare_parameter("goal_acceptance_radius", goal_acceptance_radius_);
   this->declare_parameter("obstacle_dist_threshold", obstacle_dist_threshold_);
   this->declare_parameter("mavros_map_frame", mavros_map_frame_);
   this->declare_parameter("adjust_goal", adjust_goal_);
@@ -58,7 +60,8 @@ PathManager::PathManager()
 
   std::string raw_goal_topic;
   // Params
-  this->get_parameter("acceptance_radius", acceptance_radius_);
+  this->get_parameter("setpoint_acceptance_radius", setpoint_acceptance_radius_);
+  this->get_parameter("goal_acceptance_radius", goal_acceptance_radius_);
   this->get_parameter("obstacle_dist_threshold", obstacle_dist_threshold_);
   this->get_parameter("mavros_map_frame", mavros_map_frame_);
   this->get_parameter("adjust_goal", adjust_goal_);
@@ -454,11 +457,11 @@ void PathManager::publishSetpoint() {
 }
 
 bool PathManager::isCloseToGoal() {
-  return distance(last_pos_, current_goal_) < acceptance_radius_;
+  return distance(last_pos_, current_goal_) < goal_acceptance_radius_;
 }
 
 bool PathManager::isCloseToSetpoint() {
-  return distance(last_pos_, current_setpoint_) < acceptance_radius_;
+  return distance(last_pos_, current_setpoint_) < setpoint_acceptance_radius_;
 }
 
 void PathManager::adjustSetpoint() {


### PR DESCRIPTION
Pull this and [vehicle_launch](https://github.com/robotics-88/vehicle-launch/pull/47) PR. Test in sim by sending a setpoint:

```
ros2 topic pub --once /goal_raw geometry_msgs/msg/PoseStamped "{ header: {stamp: {sec: 0.0, nanosec: 0}}, pose: {position: {x: -30.0, y: 30.0, z: 5.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}"
```

Confirm that the drone flies at normal speed with mavros setpoints, but pretty slowly during path following, and stays very close to the green path.