### PR TITLE
Fixes an issue where setpoints overwrite mavros goal

### DIFF
--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -200,6 +200,9 @@ void PathManager::publishGoal(geometry_msgs::msg::PoseStamped goal) {
     auto direction_vec = subtractPoints(current_goal_.pose.position, current_pos_.pose.position);
     double yaw_target = atan2(direction_vec.y, direction_vec.x);
 
+    // Clear path so that we're no longer publishing setpoints on the path
+    path_.clear();
+
     // Publish goal
     mavros_msgs::msg::PositionTarget setpoint;
     setpoint.header.frame_id = mavros_map_frame_;
@@ -313,7 +316,6 @@ bool PathManager::requestPath(const geometry_msgs::msg::PoseStamped goal) {
   {
     auto res_ptr = result.get();
     if (res_ptr->success) {
-      // setCurrentPath(res_ptr->path);
       return true;
     }
     else {
@@ -506,9 +508,6 @@ bool PathManager::adjustGoalAltitude(geometry_msgs::msg::PoseStamped goal) {
 }
 
 void PathManager::setCurrentPath(const nav_msgs::msg::Path &path) {
-
-  RCLCPP_INFO(this->get_logger(), "Received path, target position [%f, %f, %f]",
-                                  path.poses.back().pose.position.x, path.poses.back().pose.position.y, path.poses.back().pose.position.z);
 
   std::vector<geometry_msgs::msg::PoseStamped> poses = path.poses;
 


### PR DESCRIPTION
## Description

If the goal gets completed (i.e. we are within acceptance radius) but there's still points in the path, and the next goal is a mavros goal, the mavros goal would get overwritten by the remaining setpoints, and never get completed. This fix clears out the path when sending a mavros goal so this doesn't happen.

## Testing

Send a goal (recommended via RVIZ 2d goal pose) which will use the path planner, and then switch to MAVROS setpoints halfway. I.e. a crowded area near the drone start point, and then an open area near the goal position. Verify that the drone goes to the final position.